### PR TITLE
Use Task.Run for WebSocket listener

### DIFF
--- a/TestWebSocket.ConsoleApp/Program.cs
+++ b/TestWebSocket.ConsoleApp/Program.cs
@@ -23,7 +23,7 @@ namespace TestWebSocket.ConsoleApp
             await clientWebSocket.ConnectAsync(new Uri("ws://localhost:60616/ws"), _cts.Token);
 
             // Listening new messages
-            _ = Task.Factory.StartNew(
+            _ = Task.Run(
                 async () =>
                 {
                     var rcvBuffer = new ArraySegment<byte>(_bufferSize);
@@ -34,7 +34,7 @@ namespace TestWebSocket.ConsoleApp
                         string rcvMsg = Encoding.UTF8.GetString(msgBytes);
                         Console.WriteLine("\nMessage received: {0}", rcvMsg);
                     }
-                }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                }, _cts.Token);
 
             Console.Write("\nType in console to send messages :");
 


### PR DESCRIPTION
## Summary
- Replace `Task.Factory.StartNew` with `Task.Run` for receiving WebSocket messages.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f373686c0832b9d45118c45755076